### PR TITLE
Don't import dask and xarray by default

### DIFF
--- a/fastjmd95/jmd95wrapper.py
+++ b/fastjmd95/jmd95wrapper.py
@@ -1,29 +1,33 @@
 
 import fastjmd95.jmd95numba as jmd95numba
 
+try:
+    import dask.array as dsa
+except ImportError:
+    dsa = None
+
+try:
+    import xarray as xr
+except ImportError:
+    xr = None
+
 def _any_dask_array(*args):
-    try:
-        import dask.array as dsa
+    if dsa:
         return any([isinstance(a, dsa.core.Array) for a in args])
-    except ImportError:
-        print("Can't parse dask arrays if dask isn't installed")
+    else:
         return False
 
 def _any_xarray(*args):
-    try:
-        import xarray as xr
+    if xr:
         return any([isinstance(a, xr.DataArray) for a in args])
-    except ImportError:
-        print("Can't parse xarrays if xarray isn't installed")
+    else:
         return False
 
 def maybe_wrap_arrays(func):
     def wrapper(*args):
         if _any_dask_array(*args):
-            import dask.array as dsa
             rho = dsa.map_blocks(func,*args)
         elif _any_xarray(*args):
-            import xarray as xr
             rho = xr.apply_ufunc(func,*args,output_dtypes=[float],dask='parallelized')
         else:
             rho = func(*args)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = ["numba"]
+EXTRAS_REQUIRE = ["dask","xarray"]
 PYTHON_REQUIRES = ">=3.6"
 
 DESCRIPTION = "Numba version of Jackett & McDougall (1995) ocean equation of state."
@@ -45,6 +46,7 @@ setup(
     long_description=readme(),
     install_requires=INSTALL_REQUIRES,
     python_requires=PYTHON_REQUIRES,
+    extras_require=EXTRAS_REQUIRE,
     url=URL,
     packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = ["numba"]
-EXTRAS_REQUIRE = ["dask","xarray"]
+EXTRAS_REQUIRE = {"dask": ["dask"], "xarray": ["xarray"]}
 PYTHON_REQUIRES = ">=3.6"
 
 DESCRIPTION = "Numba version of Jackett & McDougall (1995) ocean equation of state."


### PR DESCRIPTION
I'm not super happy about having to import these things twice, but it seems as though I have to. 